### PR TITLE
Id attribute missing for top level services

### DIFF
--- a/src/Resources/config/services/association_type.xml
+++ b/src/Resources/config/services/association_type.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AssociationTypeUpdatedDenormalizer" id="sylius.denormalizer.product_association_type">
+        <service id="sylake_sylius_consumer.denormalizer.association_type_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\AssociationTypeUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\AssociationTypeProjector" id="sylius.projector.product_association_type">
+        <service id="sylake_sylius_consumer.projector.association_type" class="Sylake\SyliusConsumerPlugin\Projector\AssociationTypeProjector">
             <argument type="service" id="sylius.factory.product_association_type" />
             <argument type="service" id="sylius.repository.product_association_type" />
             <argument type="service" id="monolog.logger" />

--- a/src/Resources/config/services/association_type.xml
+++ b/src/Resources/config/services/association_type.xml
@@ -6,7 +6,7 @@
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\AssociationTypeProjector">
+        <service class="Sylake\SyliusConsumerPlugin\Projector\AssociationTypeProjector" id="sylius.projector.product_association_type">
             <argument type="service" id="sylius.factory.product_association_type" />
             <argument type="service" id="sylius.repository.product_association_type" />
             <argument type="service" id="monolog.logger" />

--- a/src/Resources/config/services/association_type.xml
+++ b/src/Resources/config/services/association_type.xml
@@ -2,7 +2,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AssociationTypeUpdatedDenormalizer">
+        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AssociationTypeUpdatedDenormalizer" id="sylius.denormalizer.product_association_type">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 

--- a/src/Resources/config/services/attribute.xml
+++ b/src/Resources/config/services/attribute.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeUpdatedDenormalizer">
+        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeUpdatedDenormalizer" id="sylius.denormalizer.product_association_type">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\AttributeProjector">
+        <service class="Sylake\SyliusConsumerPlugin\Projector\AttributeProjector" id="sylius.projector.product_association_type">
             <argument type="service" id="sylius.factory.product_attribute" />
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylius.registry.attribute_type" />

--- a/src/Resources/config/services/attribute.xml
+++ b/src/Resources/config/services/attribute.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeUpdatedDenormalizer" id="sylius.denormalizer.product_association_type">
+        <service id="sylake_sylius_consumer.denormalizer.attribute_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\AttributeProjector" id="sylius.projector.product_association_type">
+        <service id="sylake_sylius_consumer.projector.attribute" class="Sylake\SyliusConsumerPlugin\Projector\AttributeProjector">
             <argument type="service" id="sylius.factory.product_attribute" />
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylius.registry.attribute_type" />

--- a/src/Resources/config/services/attribute_option.xml
+++ b/src/Resources/config/services/attribute_option.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeOptionUpdatedDenormalizer">
+        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeOptionUpdatedDenormalizer" id="sylius.denormalizer.product_association_type">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\AttributeOptionProjector">
+        <service class="Sylake\SyliusConsumerPlugin\Projector\AttributeOptionProjector" id="sylius.projector.product_association_type">
             <argument type="service" id="sylake_sylius_consumer.repository.akeneo_attribute_option" />
             <argument type="service" id="monolog.logger" />
             <tag name="event_subscriber" subscribes_to="Sylake\SyliusConsumerPlugin\Event\AttributeOptionUpdated" method="__invoke" />

--- a/src/Resources/config/services/attribute_option.xml
+++ b/src/Resources/config/services/attribute_option.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeOptionUpdatedDenormalizer" id="sylius.denormalizer.product_association_type">
+        <service id="sylake_sylius_consumer.denormalizer.attribute_option_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\AttributeOptionUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\AttributeOptionProjector" id="sylius.projector.product_association_type">
+        <service id="sylake_sylius_consumer.projector.attribute_option" class="Sylake\SyliusConsumerPlugin\Projector\AttributeOptionProjector">
             <argument type="service" id="sylake_sylius_consumer.repository.akeneo_attribute_option" />
             <argument type="service" id="monolog.logger" />
             <tag name="event_subscriber" subscribes_to="Sylake\SyliusConsumerPlugin\Event\AttributeOptionUpdated" method="__invoke" />

--- a/src/Resources/config/services/family.xml
+++ b/src/Resources/config/services/family.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\FamilyUpdatedDenormalizer">
+        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\FamilyUpdatedDenormalizer" id="sylius.denormalizer.family">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\FamilyProjector">
+        <service class="Sylake\SyliusConsumerPlugin\Projector\FamilyProjector" id="sylius.projector.family">
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylake_sylius_consumer.repository.akeneo_attribute_option" />
             <argument type="service" id="sylius.factory.product_attribute" />

--- a/src/Resources/config/services/family.xml
+++ b/src/Resources/config/services/family.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\FamilyUpdatedDenormalizer" id="sylius.denormalizer.family">
+        <service id="sylake_sylius_consumer.denormalizer.family_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\FamilyUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\FamilyProjector" id="sylius.projector.family">
+        <service id="sylake_sylius_consumer.projector.family" class="Sylake\SyliusConsumerPlugin\Projector\FamilyProjector">
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylake_sylius_consumer.repository.akeneo_attribute_option" />
             <argument type="service" id="sylius.factory.product_attribute" />

--- a/src/Resources/config/services/group.xml
+++ b/src/Resources/config/services/group.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\GroupUpdatedDenormalizer" id="sylake_sylius_consumer.denormalizer.updated_group">
+        <service id="sylake_sylius_consumer.denormalizer.group_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\GroupUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\GroupProjector" id="sylake_sylius_consumer.projector.group">
+        <service id="sylake_sylius_consumer.projector.group" class="Sylake\SyliusConsumerPlugin\Projector\GroupProjector">
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylake_sylius_consumer.repository.akeneo_attribute_option" />
             <argument type="service" id="sylius.factory.product_attribute" />

--- a/src/Resources/config/services/group.xml
+++ b/src/Resources/config/services/group.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\GroupUpdatedDenormalizer">
+        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\GroupUpdatedDenormalizer" id="sylake_sylius_consumer.denormalizer.updated_group">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\GroupProjector">
+        <service class="Sylake\SyliusConsumerPlugin\Projector\GroupProjector" id="sylake_sylius_consumer.projector.group">
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylake_sylius_consumer.repository.akeneo_attribute_option" />
             <argument type="service" id="sylius.factory.product_attribute" />

--- a/src/Resources/config/services/product.xml
+++ b/src/Resources/config/services/product.xml
@@ -2,7 +2,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylake_sylius_consumer.denormalizer.updated_product" class="Sylake\SyliusConsumerPlugin\Denormalizer\ProductUpdatedDenormalizer">
+        <service id="sylake_sylius_consumer.denormalizer.product_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\ProductUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 

--- a/src/Resources/config/services/product.xml
+++ b/src/Resources/config/services/product.xml
@@ -2,7 +2,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\ProductUpdatedDenormalizer">
+        <service id="sylake_sylius_consumer.denormalizer.updated_product" class="Sylake\SyliusConsumerPlugin\Denormalizer\ProductUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 

--- a/src/Resources/config/services/taxon.xml
+++ b/src/Resources/config/services/taxon.xml
@@ -2,11 +2,11 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service class="Sylake\SyliusConsumerPlugin\Denormalizer\TaxonUpdatedDenormalizer">
+        <service id="sylake_sylius_consumer.denormalizer.taxon_updated" class="Sylake\SyliusConsumerPlugin\Denormalizer\TaxonUpdatedDenormalizer">
             <tag name="rabbitmq_simplebus.amqp_denormalizer" />
         </service>
 
-        <service class="Sylake\SyliusConsumerPlugin\Projector\TaxonProjector">
+        <service id="sylake_sylius_consumer.projector.taxon" class="Sylake\SyliusConsumerPlugin\Projector\TaxonProjector">
             <argument type="service" id="sylius.factory.taxon" />
             <argument type="service" id="sylius.repository.taxon" />
             <argument type="service" id="sylius.generator.taxon_slug" />


### PR DESCRIPTION
Likely due to the changes between Symfony 3 and 4 the service xml files seem to be broken.
When running `composer install` in Sylius, errors occur because of that.

This PR fixes that problem.

If you can think of better id attribute values, please comment so that I can modify them.
Needless to say that any other feedback is of course welcome.